### PR TITLE
Support for returning FormData or ReadableStreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,10 @@ By default,
 - `credentials` options passed to Fetch is set to `same-origin`
 
 Ajax module returns a freezed Object. The Object cannot be modified, deleted or added to.
+
+**If Content-Type header in response is set to:**
+
+- **application/json:** returns parsed json
+- **text/\*:** returns parsed text.
+- **multipart/form-data:** returns FormData object
+- **If none of the above matches**, returns the **[response.body](https://developer.mozilla.org/en-US/docs/Web/API/Response/body)** which is a **[ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)**. Handle this as required by your application.

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -222,9 +222,16 @@ const ajax = (function () {
   async function makeRequest(url, options) {
     return await fetch(url, options)
       .then(async (res) => {
-        const message = res.headers.get("content-type").includes("json")
-          ? await res.json()
-          : await res.text();
+        const contentType = res.headers.get("content-type");
+
+        const message =
+          contentType === "application/json"
+            ? await res.json()
+            : contentType.includes("text")
+            ? res.text()
+            : contentType === "multipart/form-data"
+            ? await res.formData()
+            : res.body; // returns a readableStream if not matching the above
 
         return [res.status, message];
       })


### PR DESCRIPTION
 - Supports returning parsed FormData or ReadableStreams based on content-type header.
- Updated relevant tests in ajax.tests.js
- Updated README.md